### PR TITLE
Add ghost ticks to exhibit current divisor on `BeatDivisorControl`

### DIFF
--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -154,12 +154,15 @@ namespace osu.Game.Screens.Edit
         /// </summary>
         /// <param name="index">The 0-based beat index.</param>
         /// <param name="beatDivisor">The beat divisor.</param>
+        /// <param name="validDivisors">The list of valid divisors which can be chosen from. Assumes ordered from low to high.</param>
         /// <returns>The applicable divisor.</returns>
-        public static int GetDivisorForBeatIndex(int index, int beatDivisor)
+        public static int GetDivisorForBeatIndex(int index, int beatDivisor, int[] validDivisors = null)
         {
+            validDivisors ??= PREDEFINED_DIVISORS;
+
             int beat = index % beatDivisor;
 
-            foreach (int divisor in PREDEFINED_DIVISORS)
+            foreach (int divisor in validDivisors)
             {
                 if ((beat * divisor) % beatDivisor == 0)
                     return divisor;

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -402,8 +402,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 for (int tickIndex = 0; tickIndex <= largestDivisor; tickIndex++)
                 {
                     int divisor = BindableBeatDivisor.GetDivisorForBeatIndex(tickIndex, largestDivisor, (int[])beatDivisor.ValidDivisors.Value.Presets);
-
                     bool isSolidTick = divisor * (largestDivisor - tickIndex) == largestDivisor;
+
                     AddInternal(new Tick(isSolidTick, divisor)
                     {
                         Anchor = Anchor.CentreLeft,

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -425,7 +425,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
                 foreach (Tick child in InternalChildren.OfType<Tick>())
                 {
-                    float newAlpha = child.Solid ? 1f : divisor.NewValue % child.Divisor == 0 ? 0.2f : 0f;
+                    float newAlpha = child.IsSolid ? 1f : divisor.NewValue % child.Divisor == 0 ? 0.2f : 0f;
                     child.FadeTo(newAlpha);
                 }
             }
@@ -497,11 +497,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             private partial class Tick : Circle
             {
-                public bool Solid;
+                public bool IsSolid;
                 public int Divisor;
-                public Tick(bool solid, int divisor)
+                public Tick(bool isSolid, int divisor)
                 {
-                    Solid = solid;
+                    IsSolid = isSolid;
                     Divisor = divisor;
                     Size = new Vector2(6f, 12) * BindableBeatDivisor.GetSize(divisor);
                     InternalChild = new Box { RelativeSizeAxes = Axes.Both };

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -398,28 +398,25 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 ClearInternal();
                 CurrentNumber.ValueChanged -= moveMarker;
 
-                foreach (int divisor in beatDivisor.ValidDivisors.Value.Presets)
+                int largestDivisor = beatDivisor.ValidDivisors.Value.Presets.Max();
+                for (int tickIndex = 0; tickIndex <= largestDivisor; tickIndex++)
                 {
-                    AddInternal(new Tick(divisor)
+                    int divisor = largestDivisor;
+                    foreach (int validDivisor in beatDivisor.ValidDivisors.Value.Presets)
+                    {
+                        if (divisor > validDivisor && (tickIndex * validDivisor) % largestDivisor == 0)
+                            divisor = validDivisor;
+                    }
+                    bool solidTick = divisor * (largestDivisor - tickIndex) == largestDivisor;
+                    AddInternal(new Tick(solidTick, divisor)
                     {
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.Centre,
                         RelativePositionAxes = Axes.Both,
                         Colour = BindableBeatDivisor.GetColourFor(divisor, colours),
-                        X = getMappedPosition(divisor),
+                        X = tickIndex / (float)largestDivisor,
                     });
                 }
-
-                // Add a fake 1/1 at the end to give context.
-                AddInternal(new Tick(1)
-                {
-                    Anchor = Anchor.CentreRight,
-                    Origin = Anchor.Centre,
-                    Depth = float.MaxValue,
-                    Alpha = 0.05f,
-                    Colour = BindableBeatDivisor.GetColourFor(1, colours),
-                });
-
                 AddInternal(marker = new Marker());
                 CurrentNumber.ValueChanged += moveMarker;
                 CurrentNumber.TriggerChange();
@@ -428,6 +425,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
             private void moveMarker(ValueChangedEvent<int> divisor)
             {
                 marker.MoveToX(getMappedPosition(divisor.NewValue), 100, Easing.OutQuint);
+
+                foreach (Tick child in InternalChildren.OfType<Tick>())
+                {
+                    float newAlpha = child.Solid ? 1f : divisor.NewValue % child.Divisor == 0 ? 0.2f : 0f;
+                    child.FadeTo(newAlpha);
+                }
             }
 
             protected override void UpdateValue(float value)
@@ -497,8 +500,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             private partial class Tick : Circle
             {
-                public Tick(int divisor)
+                public bool Solid;
+                public int Divisor;
+                public Tick(bool solid, int divisor)
                 {
+                    Solid = solid;
+                    Divisor = divisor;
                     Size = new Vector2(6f, 12) * BindableBeatDivisor.GetSize(divisor);
                     InternalChild = new Box { RelativeSizeAxes = Axes.Both };
                 }

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -402,13 +402,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 for (int tickIndex = 0; tickIndex <= largestDivisor; tickIndex++)
                 {
                     int divisor = largestDivisor;
+                    // Find lowest divisor that the tick fits into
                     foreach (int validDivisor in beatDivisor.ValidDivisors.Value.Presets)
                     {
                         if (divisor > validDivisor && (tickIndex * validDivisor) % largestDivisor == 0)
                             divisor = validDivisor;
                     }
-                    bool solidTick = divisor * (largestDivisor - tickIndex) == largestDivisor;
-                    AddInternal(new Tick(solidTick, divisor)
+
+                    bool isSolidTick = divisor * (largestDivisor - tickIndex) == largestDivisor;
+                    AddInternal(new Tick(isSolidTick, divisor)
                     {
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.Centre,
@@ -417,6 +419,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                         X = tickIndex / (float)largestDivisor,
                     });
                 }
+
                 AddInternal(marker = new Marker());
                 CurrentNumber.ValueChanged += moveMarker;
                 CurrentNumber.TriggerChange();

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -401,13 +401,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 int largestDivisor = beatDivisor.ValidDivisors.Value.Presets.Max();
                 for (int tickIndex = 0; tickIndex <= largestDivisor; tickIndex++)
                 {
-                    int divisor = largestDivisor;
-                    // Find lowest divisor that the tick fits into
-                    foreach (int validDivisor in beatDivisor.ValidDivisors.Value.Presets)
-                    {
-                        if (divisor > validDivisor && (tickIndex * validDivisor) % largestDivisor == 0)
-                            divisor = validDivisor;
-                    }
+                    int divisor = BindableBeatDivisor.GetDivisorForBeatIndex(tickIndex, largestDivisor, (int[])beatDivisor.ValidDivisors.Value.Presets);
 
                     bool isSolidTick = divisor * (largestDivisor - tickIndex) == largestDivisor;
                     AddInternal(new Tick(isSolidTick, divisor)

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -398,7 +398,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 ClearInternal();
                 CurrentNumber.ValueChanged -= moveMarker;
 
-                int largestDivisor = beatDivisor.ValidDivisors.Value.Presets.Max();
+                int largestDivisor = beatDivisor.ValidDivisors.Value.Presets.Last();
                 for (int tickIndex = 0; tickIndex <= largestDivisor; tickIndex++)
                 {
                     int divisor = BindableBeatDivisor.GetDivisorForBeatIndex(tickIndex, largestDivisor, (int[])beatDivisor.ValidDivisors.Value.Presets);


### PR DESCRIPTION
See #23581

> Seeing the last tick transparent gave me this idea (alpha is `0.2f`):
> 
>  [BeatDivisorControl.mp4 ](https://github.com/ppy/osu/assets/41743877/9a1d7560-e588-456a-9e74-549f966a0ca5)
>
> Pro: helps with the intuitive representation Con: more visual noise
> 
> Also, irrational meters look a bit weird because not all the beats to the left of the selection fit in the current divisor
> 
> ![スクリーンショット 2023-05-20 212335](https://user-images.githubusercontent.com/41743877/239706146-fd647fdf-358c-4f04-bb9a-469c7c9f69d4.png)

