### PR TITLE
Beat divisor mouse drag fix and tests

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -90,10 +90,10 @@ namespace osu.Game.Tests.Visual.Editing
 
         private Vector2 getPositionForDivisor(int divisor)
         {
-            float localX = 1 - 1 / (float)divisor;
+            float localX = (1 - 1 / (float)divisor) * tickSliderBar.UsableWidth + tickSliderBar.RangePadding;
             return tickSliderBar.ToScreenSpace(new Vector2(
                 localX,
-                0.5f
+                tickSliderBar.DrawHeight / 2
             ));
         }
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -90,12 +90,11 @@ namespace osu.Game.Tests.Visual.Editing
 
         private Vector2 getPositionForDivisor(int divisor)
         {
-            float relativePosition = (float)Math.Clamp(divisor, 0, 16) / 16;
-            var sliderDrawQuad = tickSliderBar.ScreenSpaceDrawQuad;
-            return new Vector2(
-                sliderDrawQuad.TopLeft.X + sliderDrawQuad.Width * relativePosition,
-                sliderDrawQuad.Centre.Y
-            );
+            float localX = 1 - 1 / (float)divisor;
+            return tickSliderBar.ToScreenSpace(new Vector2(
+                localX,
+                0.5f
+            ));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -65,17 +65,24 @@ namespace osu.Game.Tests.Visual.Editing
                 InputManager.MoveMouseTo(tickMarkerHead.ScreenSpaceDrawQuad.Centre);
                 InputManager.PressButton(MouseButton.Left);
             });
-            AddStep("move to 8 and release", () =>
+            AddStep("move to 1", () => InputManager.MoveMouseTo(getPositionForDivisor(1)));
+            AddStep("move to 16 and release", () =>
             {
-                InputManager.MoveMouseTo(tickSliderBar.ScreenSpaceDrawQuad.Centre);
+                InputManager.MoveMouseTo(getPositionForDivisor(16));
                 InputManager.ReleaseButton(MouseButton.Left);
             });
-            AddAssert("divisor is 8", () => bindableBeatDivisor.Value == 8);
+            AddAssert("divisor is 16", () => bindableBeatDivisor.Value == 16);
             AddStep("hold marker", () => InputManager.PressButton(MouseButton.Left));
-            AddStep("move to 16", () => InputManager.MoveMouseTo(getPositionForDivisor(16)));
-            AddStep("move to ~10 and release", () =>
+            AddStep("move to ~6 and release", () =>
+            {
+                InputManager.MoveMouseTo(getPositionForDivisor(6));
+                InputManager.ReleaseButton(MouseButton.Left);
+            });
+            AddAssert("divisor clamped to 8", () => bindableBeatDivisor.Value == 8);
+            AddStep("move to ~10 and click", () =>
             {
                 InputManager.MoveMouseTo(getPositionForDivisor(10));
+                InputManager.PressButton(MouseButton.Left);
                 InputManager.ReleaseButton(MouseButton.Left);
             });
             AddAssert("divisor clamped to 8", () => bindableBeatDivisor.Value == 8);

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -383,7 +383,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 CurrentNumber.BindTo(this.beatDivisor = beatDivisor);
 
-                Padding = new MarginPadding { Horizontal = 5 };
+                RangePadding = 5;
+                Padding = new MarginPadding { Horizontal = RangePadding };
             }
 
             protected override void LoadComplete()


### PR DESCRIPTION
For making the tests work in https://github.com/ppy/osu/pull/23581

![image](https://github.com/peppy/osu/assets/41743877/65ac3a72-27d7-420f-8d97-0f2a2afa72f4)

Includes a fix for the calculation from mouse position not taking into account padding. (which should maybe be its own issue and pr? but it's quite minor)